### PR TITLE
Update permanence indicator in the primary marquee plus a couple other things

### DIFF
--- a/index.html
+++ b/index.html
@@ -101,7 +101,7 @@
 
   <script type="text/template" id="marquee-template">
     <p class='return-msg' style="margin: 8px 0 0 12px; display: none;">EDITING</p>
-    <div class="actor-initiative">
+    <div class="actor-initiative <%= _.include(features, "persistent") ?  'persistent' : '' %>  ">
       <div class="show"><%- order %></div>
       <div class="edit-form">
         <input type="text" value="<%- order %>"/>

--- a/stylesheets/marquee.css
+++ b/stylesheets/marquee.css
@@ -12,6 +12,8 @@ body {
   -webkit-font-smoothing: antialiased;
 }
 
+input:focus { outline: none; }
+
 #actorapp {
   float: right;
   width: 267px;
@@ -59,7 +61,7 @@ body {
   width: 100%;
   padding-bottom: 15px;
   clear: both;
-  overflow: auto;
+  overflow: hidden;
 }
 
 .panel.fixed {
@@ -261,6 +263,7 @@ li:hover .destroy, li:hover .activate {
 }
 
 .actor-initiative {
+  overflow: hidden;
   clear: both;
   display: inline-block;
   float: right;
@@ -282,6 +285,10 @@ li:hover .destroy, li:hover .activate {
 }
 
 .persistent .actor-initiative {
+  background-color: #56a0ecab;
+}
+
+.persistent.actor-initiative {
   background-color: #56a0ecab;
 }
 


### PR DESCRIPTION
Remove osx outline focus on inputs
Update permanence indicator in the primary marquee 
Horizontal scroll bar regression in the actor list, Not able to reliably repeat the horizontal scroll bar issue though.

![image](https://user-images.githubusercontent.com/470759/40342727-edd4154e-5d51-11e8-9db7-340bf647cbe6.png)
<img width="429" alt="image" src="https://user-images.githubusercontent.com/470759/40342894-c9ad5b84-5d52-11e8-8817-e70f875bba67.png">
