### PR TITLE
Corrected defect in Shift-R behavior.

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -607,7 +607,7 @@ $(function(){
     },
 
     resetActorFeatures: function(actor) {
-      actor.removeTransientFeatures();
+      actor.resetFeatures();
     },
 
     resetAllActorFeatures: function() {

--- a/js/models/actor.js
+++ b/js/models/actor.js
@@ -116,10 +116,8 @@ var Actor = Backbone.Model.extend({
     }
   },
 
-  removeTransientFeatures: function() {
-    var newFeatures = _.reject(this.get('features'), function(f) {
-      return (f != 'persistent');
-    });
+  resetFeatures: function() {
+    var newFeatures = ['available', 'persistent'];
     this.save({
       'features': newFeatures
     });


### PR DESCRIPTION
As requested by Scott, upon reset all characters are displayed as 'available.'
As noted by eephillip, 'persistent' should also be maintained.
All other features, and non-persistent conditions are deleted, but persistent conditions are retained.